### PR TITLE
Fix/storybook documentation

### DIFF
--- a/src/stories/navigation/Drawer.stories.tsx
+++ b/src/stories/navigation/Drawer.stories.tsx
@@ -48,7 +48,7 @@ Default.args = {
  */
 export const BottomDrawer = Template.bind({});
 BottomDrawer.args = {
-  open: true,
+  open: false,
   anchor: "bottom",
 };
 
@@ -57,7 +57,7 @@ BottomDrawer.args = {
  */
 export const TopDrawer = Template.bind({});
 TopDrawer.args = {
-  open: true,
+  open: false,
   anchor: "top",
 };
 
@@ -66,6 +66,6 @@ TopDrawer.args = {
  */
 export const RightDrawer = Template.bind({});
 RightDrawer.args = {
-  open: true,
+  open: false,
   anchor: "right",
 };

--- a/src/stories/navigation/Drawer.stories.tsx
+++ b/src/stories/navigation/Drawer.stories.tsx
@@ -12,13 +12,26 @@ export default {
   component: Drawer,
 } as Meta;
 
-const Template: Story<DrawerProps> = (args: any) => (
-  <Drawer {...args}>
-    <Button>I am a Button in a Drawer component!</Button>
-    <Button>Set the &quot;open&quot; property to false to close me.</Button>
-    <Button>Set the &quot;open&quot; property to true to open me.</Button>
-  </Drawer>
-);
+const Template: Story<DrawerProps> = (args: any) => {
+  const [state, setState] = React.useState({
+    open: args.open,
+  });
+
+  const toggleDrawer = (open: boolean) => {
+    setState({ open: open });
+  };
+
+  return (
+    <div>
+      <Button onClick={() => toggleDrawer(true)}>{args.anchor}</Button>
+      <Drawer anchor={args.anchor} open={Boolean(state.open)} onClose={() => toggleDrawer(false)}>
+        <Button>I am a Button in a Drawer component!</Button>
+        <Button>Set the &quot;open&quot; property to false to close me.</Button>
+        <Button>Set the &quot;open&quot; property to true to open me.</Button>
+      </Drawer>
+    </div>
+  );
+};
 
 /**
  * Implementation of Drawer
@@ -27,6 +40,7 @@ const Template: Story<DrawerProps> = (args: any) => (
 export const Default = Template.bind({});
 Default.args = {
   open: true,
+  anchor: "left",
 };
 
 /**

--- a/src/stories/navigation/Menu.stories.tsx
+++ b/src/stories/navigation/Menu.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from "@storybook/react";
 import { Menu, MenuProps } from "../../components/Menu";
 import MenuItem from "../../components/MenuItem/MenuItem";
 import pkg from "../../components/Menu/package.json";
+import Button from "../../components/Button/Button";
 
 export default {
   title: "Components/Navigation/Menu",
@@ -12,24 +13,43 @@ export default {
   component: Menu,
 } as Meta;
 
-let opened = true;
+const opened = false;
 
-const Template: Story<MenuProps> = (args: any) => (
-  <Menu {...args}>
-    <MenuItem dense={false} onClick={() => (opened = false)}>
-      <p>The &quot;open&quot; property is set to true to force the menu to be visible for demo purposes.</p>
-    </MenuItem>
-    <MenuItem dense={false} onClick={() => (opened = false)}>
-      <span>Click me!</span>
-    </MenuItem>
-    <MenuItem dense={false} onClick={() => (opened = false)}>
-      <span>Or me!</span>
-    </MenuItem>
-    <MenuItem dense={false} onClick={() => (opened = false)}>
-      <span>Or me!</span>
-    </MenuItem>
-  </Menu>
-);
+const Template: Story<MenuProps> = (args: any) => {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const handleClick = (event) => 
+  {
+    setAnchorEl(event.currentTarget);
+  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  }
+  return(
+  <div>
+    <Button aria-controls="menu" onClick={handleClick}>
+      Click me!
+    </Button>
+    <Menu {...args}
+     anchorEl={anchorEl}
+     open={Boolean(anchorEl)}
+     onClose={handleClose}
+     id="menu">
+      <MenuItem dense={false} onClick={handleClose}>
+        <p>The &quot;open&quot; property is set to true to force the menu to be visible for demo purposes.</p>
+      </MenuItem>
+      <MenuItem dense={false} onClick={handleClose}>
+        <span>Click me!</span>
+      </MenuItem>
+      <MenuItem dense={false} onClick={handleClose}>
+        <span>Or me!</span>
+      </MenuItem>
+      <MenuItem dense={false} onClick={handleClose}>
+        <span>Or me!</span>
+      </MenuItem>
+    </Menu>
+  </div>
+   );
+};
 
 /**
  * Default implementation of the Menu component.
@@ -37,7 +57,7 @@ const Template: Story<MenuProps> = (args: any) => (
  */
 export const Default = Template.bind({});
 Default.args = {
-  open: opened,
+  open: opened
 };
 
 /**

--- a/src/stories/navigation/MenuItem.stories.tsx
+++ b/src/stories/navigation/MenuItem.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from "@storybook/react";
 import { MenuItem, MenuItemProps } from "../../components/MenuItem";
 import Menu from "../../components/Menu/Menu";
 import pkg from "../../components/MenuItem/package.json";
-import Button from "@gemeente-denhaag/button";
+import Button from "../../components/button";
 
 export default {
   title: "Components/Navigation/Menu/MenuItem",

--- a/src/stories/navigation/MenuItem.stories.tsx
+++ b/src/stories/navigation/MenuItem.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from "@storybook/react";
 import { MenuItem, MenuItemProps } from "../../components/MenuItem";
 import Menu from "../../components/Menu/Menu";
 import pkg from "../../components/MenuItem/package.json";
-import Button from "../../components/button";
+import Button from "../../components/Button/Button";
 
 export default {
   title: "Components/Navigation/Menu/MenuItem",

--- a/src/stories/navigation/MenuItem.stories.tsx
+++ b/src/stories/navigation/MenuItem.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, Story } from "@storybook/react";
 import { MenuItem, MenuItemProps } from "../../components/MenuItem";
 import Menu from "../../components/Menu/Menu";
 import pkg from "../../components/MenuItem/package.json";
+import Button from "@gemeente-denhaag/button";
 
 export default {
   title: "Components/Navigation/Menu/MenuItem",
@@ -12,13 +13,27 @@ export default {
   component: MenuItem,
 } as Meta;
 
-const Template: Story<MenuItemProps> = (args: any) => (
-  <Menu open anchorEl={null}>
-    <MenuItem {...args}>
-      <p>This is a MenuItem.</p>
-    </MenuItem>
-  </Menu>
-);
+const Template: Story<MenuItemProps> = (args: any) => {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  return (
+    <div>
+      <Button aria-controls="menu" onClick={handleClick}>
+        Click me!
+      </Button>
+      <Menu {...args} anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose} id="menu">
+        <MenuItem {...args}>
+          <p>This is a MenuItem.</p>
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};
 
 /**
  * Implementation of MenuItem

--- a/src/stories/navigation/SwipeableDrawer.stories.tsx
+++ b/src/stories/navigation/SwipeableDrawer.stories.tsx
@@ -12,12 +12,25 @@ export default {
   component: SwipeableDrawer,
 } as Meta;
 
-const Template: Story<SwipeableDrawerProps> = (args: any) => (
-  <SwipeableDrawer {...args}>
-    <p>This Drawer is swipeable, drag it to hide it.</p>
-    <Button>Push me or swipe me on a phone!</Button>
-  </SwipeableDrawer>
-);
+const Template: Story<SwipeableDrawerProps> = (args: any) => {
+  const [state, setState] = React.useState({
+    open: args.open,
+  });
+
+  const toggleDrawer = (open: boolean) => {
+    setState({ open: open });
+  };
+
+  return (
+    <div>
+      <Button onClick={() => toggleDrawer(true)}>Open Menu</Button>
+      <SwipeableDrawer {...args} open={Boolean(state.open)} onClose={() => toggleDrawer(false)}>
+        <p>This Drawer is swipeable, drag it to hide it.</p>
+        <Button>Push me or swipe me on a phone!</Button>
+      </SwipeableDrawer>
+    </div>
+  );
+};
 
 /**
  * Implementation of SwipeableDrawer

--- a/src/stories/surfaces/AppBar.stories.tsx
+++ b/src/stories/surfaces/AppBar.stories.tsx
@@ -50,6 +50,9 @@ const Template: Story<AppBarProps> = (args: any) => {
  * Implementation of AppBar
  */
 export const Default = Template.bind({});
+Default.args = {
+  position: "relative",
+}
 
 /**
  * Statically positioned AppBar
@@ -64,5 +67,6 @@ StaticPosition.args = {
  */
 export const SecondaryColoured = Template.bind({});
 SecondaryColoured.args = {
+  position: "static",
   color: "secondary",
 };


### PR DESCRIPTION
This PR resolves #23.

The issue stated that Drawer should not have an overlay on the documentation page, however the drawer component is always "fixed" and cannot be refitted into another component. This is also how MUI does it on their Drawer demo's.
This PR makes the documentation page usable for all components.

There is one issue with Menu, since it has a popup which needs an anchor. When the component prop open=true the component is rerendered and I could not set it to the correct anchor. Something like componentDidMount would allow us to set the anchor correctly but I could not find such thing in Storybook. Long story short: the open property on Menu is not working yet in Storybook but I don't see this as a blocking problem since the story does work otherwise.