### PR TITLE
Add base styles package

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -29,7 +29,7 @@
     "unit-no-unknown": [true],
     "alpha-value-notation": ["percentage"],
     "hue-degree-notation": ["number"],
-    "color-function-notation": ["legacy"],
+    "color-function-notation": ["modern"],
     "length-zero-no-unit": [true, "custom-properties"],
     "font-weight-notation": [
       "numeric",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -29,7 +29,7 @@
     "unit-no-unknown": [true],
     "alpha-value-notation": ["percentage"],
     "hue-degree-notation": ["number"],
-    "color-function-notation": ["modern"],
+    "color-function-notation": ["legacy"],
     "length-zero-no-unit": [true, "custom-properties"],
     "font-weight-notation": [
       "numeric",

--- a/src/components/BaseStyles/globals.module.css
+++ b/src/components/BaseStyles/globals.module.css
@@ -1,45 +1,45 @@
 :root {
   /* Colors */
-  --denhaag-green-1: hsl(117, 28%, 87%);
-  --denhaag-green-2: hsl(118, 28%, 60%);
-  --denhaag-green-3: hsl(138, 58%, 33%);
-  --denhaag-green-4: hsl(138, 57%, 27%);
-  --denhaag-green-5: hsl(139, 100%, 9%);
+  --denhaag-green-1: hsl(117 28% 87%);
+  --denhaag-green-2: hsl(118 28% 60%);
+  --denhaag-green-3: hsl(138 58% 33%);
+  --denhaag-green-4: hsl(138 57% 27%);
+  --denhaag-green-5: hsl(139 100% 9%);
 
-  --denhaag-blue-1: hsl(208, 76%, 92%);
-  --denhaag-blue-2: hsl(210, 64%, 80%);
-  --denhaag-blue-3: hsl(207, 80%, 35%);
-  --denhaag-blue-4: hsl(207, 87%, 27%);
-  --denhaag-blue-5: hsl(207, 93%, 16%);
+  --denhaag-blue-1: hsl(208 76% 92%);
+  --denhaag-blue-2: hsl(210 64% 80%);
+  --denhaag-blue-3: hsl(207 80% 35%);
+  --denhaag-blue-4: hsl(207 87% 27%);
+  --denhaag-blue-5: hsl(207 93% 16%);
 
-  --denhaag-ocher-1: hsl(50, 100%, 91%);
-  --denhaag-ocher-2: hsl(50, 100%, 76%);
-  --denhaag-ocher-3: hsl(50, 94%, 57%);
-  --denhaag-ocher-4: hsl(47, 100%, 40%);
-  --denhaag-ocher-5: hsl(47, 100%, 25%);
+  --denhaag-ocher-1: hsl(50 100% 91%);
+  --denhaag-ocher-2: hsl(50 100% 76%);
+  --denhaag-ocher-3: hsl(50 94% 57%);
+  --denhaag-ocher-4: hsl(47 100% 40%);
+  --denhaag-ocher-5: hsl(47 100% 25%);
 
-  --denhaag-red-1: hsl(4, 100%, 92%);
-  --denhaag-red-2: hsl(5, 75%, 72%);
-  --denhaag-red-3: hsl(6, 93%, 42%);
-  --denhaag-red-4: hsl(2, 100%, 32%);
-  --denhaag-red-5: hsl(1, 100%, 16%);
+  --denhaag-red-1: hsl(4 100% 92%);
+  --denhaag-red-2: hsl(5 75% 72%);
+  --denhaag-red-3: hsl(6 93% 42%);
+  --denhaag-red-4: hsl(2 100% 32%);
+  --denhaag-red-5: hsl(1 100% 16%);
 
-  --denhaag-orange-1: hsl(34, 100%, 84%);
-  --denhaag-orange-2: hsl(34, 100%, 68%);
-  --denhaag-orange-3: hsl(34, 100%, 47%);
-  --denhaag-orange-4: hsl(23, 99%, 44%);
-  --denhaag-orange-5: hsl(23, 100%, 27%);
+  --denhaag-orange-1: hsl(34 100% 84%);
+  --denhaag-orange-2: hsl(34 100% 68%);
+  --denhaag-orange-3: hsl(34 100% 47%);
+  --denhaag-orange-4: hsl(23 99% 44%);
+  --denhaag-orange-5: hsl(23 100% 27%);
 
-  --denhaag-grey-1: hsl(0, 0%, 95%);
-  --denhaag-grey-2: hsl(0, 0%, 82%);
-  --denhaag-grey-3: hsl(0, 0%, 48%);
-  --denhaag-grey-4: hsl(0, 0%, 29%);
+  --denhaag-grey-1: hsl(0 0% 95%);
+  --denhaag-grey-2: hsl(0 0% 82%);
+  --denhaag-grey-3: hsl(0 0% 48%);
+  --denhaag-grey-4: hsl(0 0% 29%);
 
-  --denhaag-warmgrey: hsl(40, 18%, 97%);
+  --denhaag-warmgrey: hsl(40 18% 97%);
 
-  --denhaag-black: hsl(0, 0%, 0%);
+  --denhaag-black: hsl(0 0% 0%);
 
-  --denhaag-white: hsl(0, 0%, 100%);
+  --denhaag-white: hsl(0 0% 100%);
 
   /* Font sizes */
   font-size: 16px;

--- a/src/components/BaseStyles/globals.module.css
+++ b/src/components/BaseStyles/globals.module.css
@@ -1,6 +1,6 @@
 :root {
   /* Colors */
-  --denhaag-green-1: hsl(116, 29%, 78%);
+  --denhaag-green-1: hsl(117, 28%, 87%);
   --denhaag-green-2: hsl(118, 28%, 60%);
   --denhaag-green-3: hsl(138, 58%, 33%);
   --denhaag-green-4: hsl(138, 57%, 27%);

--- a/src/components/BaseStyles/globals.module.css
+++ b/src/components/BaseStyles/globals.module.css
@@ -1,45 +1,45 @@
 :root {
   /* Colors */
-  --denhaag-green-1: #D5E7D4;
-  --denhaag-green-2: #7EB57C;
-  --denhaag-green-3: #248641;
-  --denhaag-green-4: #1D6B34;
-  --denhaag-green-5: #00300F;
+  --denhaag-green-1: hsl(116, 29%, 78%);
+  --denhaag-green-2: hsl(118, 28%, 60%);
+  --denhaag-green-3: hsl(138, 58%, 33%);
+  --denhaag-green-4: hsl(138, 57%, 27%);
+  --denhaag-green-5: hsl(139, 100%, 9%);
 
-  --denhaag-blue-1: #DAEBFA;
-  --denhaag-blue-2: #ADCDED;
-  --denhaag-blue-3: #1261A3;
-  --denhaag-blue-4: #094B81;
-  --denhaag-blue-5: #032C4E;
+  --denhaag-blue-1: hsl(208, 76%, 92%);
+  --denhaag-blue-2: hsl(210, 64%, 80%);
+  --denhaag-blue-3: hsl(207, 80%, 35%);
+  --denhaag-blue-4: hsl(207, 87%, 27%);
+  --denhaag-blue-5: hsl(207, 93%, 16%);
 
-  --denhaag-ocher-1: #FFF7D1;
-  --denhaag-ocher-2: #FFEB85;
-  --denhaag-ocher-3: #F8D62D;
-  --denhaag-ocher-4: #CCA000;
-  --denhaag-ocher-5: #7D6200;
+  --denhaag-ocher-1: hsl(50, 100%, 91%);
+  --denhaag-ocher-2: hsl(50, 100%, 76%);
+  --denhaag-ocher-3: hsl(50, 94%, 57%);
+  --denhaag-ocher-4: hsl(47, 100%, 40%);
+  --denhaag-ocher-5: hsl(47, 100%, 25%);
 
-  --denhaag-red-1: #FFD7D4;
-  --denhaag-red-2: #ED8980;
-  --denhaag-red-3: #CF1C08;
-  --denhaag-red-4: #A30500;
-  --denhaag-red-5: #540200;
+  --denhaag-red-1: hsl(4, 100%, 92%);
+  --denhaag-red-2: hsl(5, 75%, 72%);
+  --denhaag-red-3: hsl(6, 93%, 42%);
+  --denhaag-red-4: hsl(2, 100%, 32%);
+  --denhaag-red-5: hsl(1, 100%, 16%);
 
-  --denhaag-orange-1: #FFDBAD;
-  --denhaag-orange-2: #FFB85E;
-  --denhaag-orange-3: #F18700;
-  --denhaag-orange-4: #E15601;
-  --denhaag-orange-5: #8C3600;
+  --denhaag-orange-1: hsl(34, 100%, 84%);
+  --denhaag-orange-2: hsl(34, 100%, 68%);
+  --denhaag-orange-3: hsl(34, 100%, 47%);
+  --denhaag-orange-4: hsl(23, 99%, 44%);
+  --denhaag-orange-5: hsl(23, 100%, 27%);
 
-  --denhaag-grey-1: #F1F1F1;
-  --denhaag-grey-2: #D2D2D2;
-  --denhaag-grey-3: #7A7A7A;
-  --denhaag-grey-4: #4B4B4B;
+  --denhaag-grey-1: hsl(0, 0%, 95%);
+  --denhaag-grey-2: hsl(0, 0%, 82%);
+  --denhaag-grey-3: hsl(0, 0%, 48%);
+  --denhaag-grey-4: hsl(0, 0%, 29%);
 
-  --denhaag-warmgrey: #F8F7F5;
+  --denhaag-warmgrey: hsl(40, 18%, 97%);
 
-  --denhaag-black: #000000;
+  --denhaag-black: hsl(0, 0%, 0%);
 
-  --denhaag-white: #FFFFFF;
+  --denhaag-white: hsl(0, 0%, 100%);
 
   /* Font sizes */
   font-size: 16px;

--- a/src/components/BaseStyles/globals.module.css
+++ b/src/components/BaseStyles/globals.module.css
@@ -1,0 +1,61 @@
+:root {
+  /* Colors */
+  --denhaag-green-1: #D5E7D4;
+  --denhaag-green-2: #7EB57C;
+  --denhaag-green-3: #248641;
+  --denhaag-green-4: #1D6B34;
+  --denhaag-green-5: #00300F;
+
+  --denhaag-blue-1: #DAEBFA;
+  --denhaag-blue-2: #ADCDED;
+  --denhaag-blue-3: #1261A3;
+  --denhaag-blue-4: #094B81;
+  --denhaag-blue-5: #032C4E;
+
+  --denhaag-ocher-1: #FFF7D1;
+  --denhaag-ocher-2: #FFEB85;
+  --denhaag-ocher-3: #F8D62D;
+  --denhaag-ocher-4: #CCA000;
+  --denhaag-ocher-5: #7D6200;
+
+  --denhaag-red-1: #FFD7D4;
+  --denhaag-red-2: #ED8980;
+  --denhaag-red-3: #CF1C08;
+  --denhaag-red-4: #A30500;
+  --denhaag-red-5: #540200;
+
+  --denhaag-orange-1: #FFDBAD;
+  --denhaag-orange-2: #FFB85E;
+  --denhaag-orange-3: #F18700;
+  --denhaag-orange-4: #E15601;
+  --denhaag-orange-5: #8C3600;
+
+  --denhaag-grey-1: #F1F1F1;
+  --denhaag-grey-2: #D2D2D2;
+  --denhaag-grey-3: #7A7A7A;
+  --denhaag-grey-4: #4B4B4B;
+
+  --denhaag-warmgrey: #F8F7F5;
+
+  --denhaag-black: #000000;
+
+  --denhaag-white: #FFFFFF;
+
+  /* Font sizes */
+  font-size: 16px;
+
+  --denhaag-fontsize-xs: 0.625rem;
+  --denhaag-fontsize-s: 0.75rem;
+  --denhaag-fontsize-base: 1rem;
+  --denhaag-fontsize-lg: 1.25rem;
+  --denhaag-fontsize-xl: 1.5rem;
+  --denhaag-fontsize-2xl: 2rem;
+  --denhaag-fontsize-3xl: 3rem;
+
+  /* Borders */
+  --denhaag-border-radius: 3px;
+
+  /* Focus state */
+  --denhaag-focus-border-color: var(--denhaag-ocher-4);
+  --denhaag-focus-border: 2px dashed var(--denhaag-focus-border-color);
+}

--- a/src/components/BaseStyles/index.ts
+++ b/src/components/BaseStyles/index.ts
@@ -1,0 +1,1 @@
+export default require("./globals.module.css")

--- a/src/components/BaseStyles/package.json
+++ b/src/components/BaseStyles/package.json
@@ -3,6 +3,8 @@
   "description": "A BaseStyles component",
   "author": "Municipality of The Hague",
   "license": "EUPL-1.2",
+  "main": "index.tsx",
+  "module": "index.ts",
   "version": "0.1.0",
   "repository": {
     "type": "git",

--- a/src/components/BaseStyles/package.json
+++ b/src/components/BaseStyles/package.json
@@ -3,7 +3,7 @@
   "description": "A BaseStyles component",
   "author": "Municipality of The Hague",
   "license": "EUPL-1.2",
-  "main": "index.tsx",
+  "main": "index.ts",
   "module": "index.ts",
   "version": "0.1.0",
   "repository": {

--- a/src/components/BaseStyles/package.json
+++ b/src/components/BaseStyles/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@gemeente-denhaag/basestyles",
+  "description": "A BaseStyles component",
+  "author": "Municipality of The Hague",
+  "license": "EUPL-1.2",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/BaseStyles"
+  },
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues"
+}


### PR DESCRIPTION
To prevent duplicate styles, a shared base styles package should be available for all components to depend on.

The globals.module.css contains the styles as defined in the [Design Systems identity](https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=43%3A338)