### PR TITLE
Added the tabindex property to IconButton

### DIFF
--- a/src/components/BaseProps/src/index.tsx
+++ b/src/components/BaseProps/src/index.tsx
@@ -13,6 +13,11 @@ export default interface BaseProps {
    * Override or extend the styles applied to the component.
    */
   classes?: Record<string, unknown>;
+
+  /**
+   * The tab-index applied to the root element of the component.
+   */
+  tabIndex?: number;
 }
 
 /**

--- a/src/components/IconButton/src/index.tsx
+++ b/src/components/IconButton/src/index.tsx
@@ -35,11 +35,6 @@ export interface IconButtonProps extends BaseProps {
    * `small` is equivalent to the dense button styling.
    */
   size?: 'small' | 'medium';
-
-  /**
-   * The tab-index of the IconButton.
-   */
-  tabIndex?: number;
 }
 
 /**

--- a/src/components/IconButton/src/index.tsx
+++ b/src/components/IconButton/src/index.tsx
@@ -35,6 +35,11 @@ export interface IconButtonProps extends BaseProps {
    * `small` is equivalent to the dense button styling.
    */
   size?: 'small' | 'medium';
+
+  /**
+   * The tab-index of the IconButton.
+   */
+  tabIndex?: number;
 }
 
 /**
@@ -43,11 +48,11 @@ export interface IconButtonProps extends BaseProps {
  * @constructor Constructs an instance of IconButton.
  */
 export const IconButton: React.FC<IconButtonProps> = ({
-  color = "inherit",
+  color = 'inherit',
   disabled = false,
   disableFocusRipple = false,
   edge = false,
-  size = "medium",
+  size = 'medium',
   ...props
 }: IconButtonProps) => {
   return (


### PR DESCRIPTION
This might not be something we want to expose like this, but tabIndex is necessary for the design implementation for list.