### PR TITLE
Reproducible builds using exact version from Yarn lockfile

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,7 +25,7 @@ jobs:
       - name: yarn install, build storybook
         run: |
           npm install -g yarn
-          yarn install
+          yarn install --frozen-lockfile
           yarn build-storybook
 
       - name: Upload storybook

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-yarn install
+yarn install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class Example extends Component {
 4. Run the following command to install all development dependencies:
 
 ```bash
-yarn install
+yarn install --frozen-lockfile
 ```
 
 #### Folder structure


### PR DESCRIPTION
I noticed we had a lot of issues with situations that were not easy to reproduce across machines and a lot of "works on my machine" situations. This PR changes the yarn installation command to use the exact versions that were tested in the PR that updated the dependencies.

Since this repository uses Dependabot to stay up to date with the latest versions of dependencies (and incidentally the test scripts of GitHub Actions will test if the upgrade would break anything) there should be no need to rely on the flexible version ranges (`^1.0.0` and `~1.0.0`) in the `package.json` file.