### PR TITLE
Update github configs to use master branch instead of development

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -29,7 +29,7 @@ To be completed before the issue can be added to backlog.
 - [ ] Acceptance criteria are described
 - [ ] Any preconditions are described
 - [ ] Possible dependence on external experts is mentioned
-- [ ] The story must be approved and understood by maintainers
+- [ ] The story must be understandable for the development team
 - [ ] Any requirements for accessibility are described
 
 ### Definition of Done

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -29,16 +29,17 @@ To be completed before the issue can be added to backlog.
 - [ ] Acceptance criteria are described
 - [ ] Any preconditions are described
 - [ ] Possible dependence on external experts is mentioned
-- [ ] The story must be understandable for the development team
+- [ ] The story must be approved and understood by maintainers
 - [ ] Any requirements for accessibility are described
 
 ### Definition of Done
 <!-- Do not change. -->
 To be completed before the issue can be marked as Done.
+- [ ] Code exists on master branch
 - [ ] Meets acceptance criteria
 - [ ] Complies with [the standard of public code](https://standard.publiccode.net/)
 - [ ] Story has been sufficiently tested
-    - [ ] 90% code coverage
+    - [ ] Maximum realistic code coverage
     - [ ] Build completed
     - [ ] Existing tests pass
 - [ ] The frontend component complies with [WCAG 2.1 accessibility guidelines](https://www.w3.org/TR/WCAG21/)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -39,7 +39,7 @@ To be completed before the issue can be marked as Done.
 - [ ] Meets acceptance criteria
 - [ ] Complies with [the standard of public code](https://standard.publiccode.net/)
 - [ ] Story has been sufficiently tested
-    - [ ] Maximum realistic code coverage
+    - [ ] 90% code coverage
     - [ ] Build completed
     - [ ] Existing tests pass
 - [ ] The frontend component complies with [WCAG 2.1 accessibility guidelines](https://www.w3.org/TR/WCAG21/)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "development"
+    target-branch: "master"
     versioning-strategy: "increase-if-necessary"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,11 +3,11 @@ name: Build and deploy Storybook to Azure Web App
 on:
   push:
     branches:
-      - development
+      - latest
       - master
   pull_request:
     branches:
-      - development
+      - latest
       - master
 
 jobs:
@@ -43,7 +43,7 @@ jobs:
 
   deploy-staging:
     needs: build
-    if: github.ref == 'refs/heads/development'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
     steps:
@@ -63,7 +63,7 @@ jobs:
 
   deploy-production:
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/latest'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR updates the github configuration files (such as `cicd.yaml` and dependabot) to respect the new branching strategy, which removes the development branch.

Closes #199 Remove dev branch