### PR TITLE
Add type to onClick function in ButtonProps

### DIFF
--- a/src/components/Button/src/index.tsx
+++ b/src/components/Button/src/index.tsx
@@ -10,7 +10,7 @@ export interface ButtonProps extends BaseProps {
   /**
    * Simple click handler
    */
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 
   /**
    * Size of the component
@@ -61,15 +61,17 @@ export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
 
   return (
     <StylesProvider injectFirst>
-      <MaterialButton classes={classes}
-                      className={sizeClass}
-                      variant={muiVariant}
-                      onClick={props.onClick}
-                      disabled={props.disabled}
-                      type={props.type}
-                      startIcon={props.startIcon}
-                      endIcon={props.endIcon}
-                      disableRipple>
+      <MaterialButton
+        classes={classes}
+        className={sizeClass}
+        variant={muiVariant}
+        onClick={props.onClick}
+        disabled={props.disabled}
+        type={props.type}
+        startIcon={props.startIcon}
+        endIcon={props.endIcon}
+        disableRipple
+      >
         {props.children}
       </MaterialButton>
     </StylesProvider>


### PR DESCRIPTION
The onClick function in the ButtonProps interface has no type. React provides [Synthetic events](https://reactjs.org/docs/events.html) that wrap around native browser events. This PR allows users to access a MouseEvent.

**Closing issues**
closes #103 Button OnClick prop type is incorrect
