### PR TITLE
Introduced disallow any rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -106,6 +106,7 @@
     "no-useless-concat": "error",
     "no-useless-escape": "error",
     "no-useless-return": "error",
+    "@typescript-eslint/no-explicit-any": "error",
     "no-void": "error",
     "no-with": "error",
     "prefer-regex-literals": "error",

--- a/src/components/Accordion/src/Accordion.stories.tsx
+++ b/src/components/Accordion/src/Accordion.stories.tsx
@@ -18,7 +18,7 @@ export default {
   component: Accordion,
 } as Meta;
 
-const Template: Story<AccordionProps> = (args: any) => (
+const Template: Story<AccordionProps> = (args: AccordionProps) => (
   <Accordion {...args}>
     <AccordionSummary expandIcon={<ChevronDownIcon />}>
       <Typography>Click me to collapse me!</Typography>

--- a/src/components/Accordion/src/Accordion.tsx
+++ b/src/components/Accordion/src/Accordion.tsx
@@ -6,7 +6,7 @@ export interface AccordionProps extends BaseProps {
   /**
    * Content of the component.
    */
-  children: React.ReactElement;
+  children: React.ReactElement[];
 
   /**
    * If true, expands the Accordion by default.

--- a/src/components/FormControlLabel/src/index.tsx
+++ b/src/components/FormControlLabel/src/index.tsx
@@ -11,7 +11,7 @@ export interface FormControlLabelProps extends BaseClassesProps {
   /**
    *A control instance, it can be a Radio, a Switch or a Checkbox.
    */
-  control: ReactElement<any, any>;
+  control: ReactElement;
 
   /**
    * If true, the component will be disabled.
@@ -36,14 +36,14 @@ export interface FormControlLabelProps extends BaseClassesProps {
   /**
    * The value of the component.
    */
-  value?: any;
+  value?: unknown;
 }
 
 /**
  * FormControlLabels allow the developer to add a label to some components
  */
 export const FormControlLabel: React.FC<FormControlLabelProps> = (props: FormControlLabelProps) => {
-  return <MaterialFormControlLabel {...props} />;
+  return <MaterialFormControlLabel {...props}/>;
 };
 
 /**

--- a/src/components/List/src/List.tsx
+++ b/src/components/List/src/List.tsx
@@ -24,7 +24,7 @@ export interface ListProps extends BaseProps {
   /**
    * The content of the subheader, normally `ListSubheader`.
    */
-  subheader?: React.ReactElement<any, any>;
+  subheader?: React.ReactElement;
 }
 
 /**

--- a/src/components/List/src/ListItem.tsx
+++ b/src/components/List/src/ListItem.tsx
@@ -19,7 +19,7 @@ export interface ListItemProps extends BaseProps {
    * If `true`, the list item will be a button (using `ButtonBase`). Props intended
    * for `ButtonBase` can then be applied to `ListItem`.
    */
-  button?: any;
+  button?: false;
 
   /**
    * The component used for the root node.
@@ -68,7 +68,11 @@ export interface ListItemProps extends BaseProps {
  * Primary UI component for user interaction
  */
 export const ListItem: React.FC<ListItemProps> = (props: ListItemProps) => {
-  return <MaterialListItem {...props}>{props.children}</MaterialListItem>;
+  return (
+    <MaterialListItem {...props}>
+      {props.children}
+    </MaterialListItem>
+  );
 };
 
 export default ListItem;

--- a/src/components/List/src/ListItemAvatar.tsx
+++ b/src/components/List/src/ListItemAvatar.tsx
@@ -6,7 +6,7 @@ export interface ListItemAvatarProps extends BaseProps {
   /**
    * The content of the component.
    */
-  children: React.ReactElement<any, any>;
+  children: React.ReactElement;
 }
 
 /**

--- a/src/components/Menu/src/Popover.tsx
+++ b/src/components/Menu/src/Popover.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import MaterialPopover from '@material-ui/core/Popover';
+import MaterialPopover, { PopoverActions, PopoverProps as MaterialPopoverProps } from '@material-ui/core/Popover';
 import BaseProps from '@gemeente-denhaag/baseprops';
 
 export interface PopoverProps extends BaseProps {
   /**
    * A ref for imperative actions.
    */
-  action: () => any;
+  action: () => React.Ref<PopoverActions>;
 
   /**
    * A HTML element, or a function that returns it.
@@ -49,37 +49,37 @@ export interface PopoverProps extends BaseProps {
   /**
    * Callback fired when the component requests to be closed.
    */
-  onClose: () => any;
+  onClose: () => MaterialPopoverProps['onClose'];
 
   /**
    * Callback fired before the component is entering.
    */
-  onEnter: () => any;
+  onEnter: () => MaterialPopoverProps['onEnter'];
 
   /**
    * Callback fired when the component has entered.
    */
-  onEntered: () => any;
+  onEntered: () => MaterialPopoverProps['onEntered'];
 
   /**
    * Callback fired when the component is entering.
    */
-  onEntering: () => any;
+  onEntering: () => MaterialPopoverProps['onEntering'];
 
   /**
    * Callback fired before the component is exiting.
    */
-  onExit: () => any;
+  onExit: () => MaterialPopoverProps['onExit'];
 
   /**
    * Callback fired when the component has exited.
    */
-  onExited: () => any;
+  onExited: () => MaterialPopoverProps['onExited'];
 
   /**
    * Callback fired when the component is exiting.
    */
-  onExiting: () => any;
+  onExiting: () => MaterialPopoverProps['onExiting'];
 
   /**
    * If true, the popover is visible.
@@ -116,7 +116,11 @@ export interface PopoverProps extends BaseProps {
  * @constructor Constructs an instance of Popover.
  */
 export const Popover: React.FC<PopoverProps> = (props: PopoverProps) => {
-  return <MaterialPopover {...props}>{props.children}</MaterialPopover>;
+  return (
+    <MaterialPopover {...props}>
+      {props.children}
+    </MaterialPopover>
+  );
 };
 
 export default Popover;

--- a/src/components/Menu/src/Popper.tsx
+++ b/src/components/Menu/src/Popper.tsx
@@ -1,5 +1,5 @@
-import React, { RefObject } from 'react';
-import MaterialPopper from '@material-ui/core/Popper';
+import React from 'react';
+import MaterialPopper, { PopperProps as MaterialPopperProps } from '@material-ui/core/Popper';
 import { BaseChildrenProps } from '@gemeente-denhaag/baseprops';
 
 export interface PopperProps extends BaseChildrenProps {
@@ -58,7 +58,7 @@ export interface PopperProps extends BaseChildrenProps {
   /**
    * A ref that points to the used popper instance.
    */
-  popperRef?: RefObject<any>;
+  popperRef?: MaterialPopperProps['popperRef'];
 
   /**
    * Help supporting a react-transition-group/Transition component.

--- a/src/components/Pickers/src/BaseDatePickerProps/BaseDatePickerProps.tsx
+++ b/src/components/Pickers/src/BaseDatePickerProps/BaseDatePickerProps.tsx
@@ -4,7 +4,7 @@ import { IconButtonProps, PopoverProps, TextFieldProps } from '@material-ui/core
 
 import { DialogProps } from '@material-ui/core/Dialog/Dialog';
 
-import { ReactElement, ReactNode, ComponentClass, FunctionComponent } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { ToolbarComponentProps } from '@material-ui/pickers/Picker/Picker';
 
 export interface BaseDatePickerProps {
@@ -12,12 +12,12 @@ export interface BaseDatePickerProps {
    * Onchange callback @DateIOType
    * @param date The Date value of the DatePicker
    */
-  onChange: (date: any) => void;
+  onChange: (date: DateIOType) => void;
 
   /**
    * DatePicker value
    */
-  value: any;
+  value: ParsableDate;
 
   /**
    * Enables keyboard listener for moving between days in calendar
@@ -242,7 +242,7 @@ export interface BaseDatePickerProps {
   /**
    * Override input component
    */
-  TextFieldComponent?: ComponentClass<TextFieldProps, any> | FunctionComponent<TextFieldProps>;
+  TextFieldComponent?: React.ComponentType<TextFieldProps>;
 
   /**
    * "TODAY" label message
@@ -252,7 +252,7 @@ export interface BaseDatePickerProps {
   /**
    * Component that will replace default toolbar renderer
    */
-  ToolbarComponent?: ComponentClass<ToolbarComponentProps, any> | FunctionComponent<ToolbarComponentProps>;
+  ToolbarComponent?: React.ComponentType<ToolbarComponentProps>;
 
   /**
    * Picker container option

--- a/src/components/Pickers/src/DatePicker.stories.tsx
+++ b/src/components/Pickers/src/DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import DateFnsUtils from '@date-io/date-fns';
-import { DatePicker, DatePickerProps } from '.';
+import { DateIOType, DatePicker, DatePickerProps } from '.';
 import PickersUtilsProvider from '../../PickersUtilsProvider';
 import pkg from '../package.json';
 
@@ -15,8 +15,8 @@ export default {
 
 const Template: Story<DatePickerProps> = (args: DatePickerProps) => {
   const [value, setValue] = React.useState('1970-01-01');
-  args.onChange = (newValue: any) => {
-    setValue(newValue);
+  args.onChange = (date: DateIOType) => {
+    setValue(date.toString());
   };
   args.value = value;
 
@@ -34,8 +34,8 @@ import DateFnsUtils from "@date-io/date-fns";
 const [value, setValue] = React.useState("1970-01-01");
 
 <PickersUtilsProvider utils={DateFnsUtils}>
-  <DatePicker value={value} onChange={(newValue: any) => {
-    setValue(newValue);
+  <DatePicker value={value} onChange={(date: DateIOType) => {
+    setValue(date.toString());
   }}/>
 </PickersUtilsProvider>
 `;

--- a/src/components/Pickers/src/DatePicker/DatePicker.tsx
+++ b/src/components/Pickers/src/DatePicker/DatePicker.tsx
@@ -5,7 +5,7 @@ import BaseDatePickerProps from '../BaseDatePickerProps/BaseDatePickerProps';
 export type DatePickerProps = BaseDatePickerProps;
 
 export const DatePicker: React.FC<DatePickerProps> = (props: DatePickerProps) => {
-  return <MaterialDatePicker {...props} />;
+  return <MaterialDatePicker {...props}/>;
 };
 
 export default DatePicker;

--- a/src/components/Pickers/src/KeyBoardDatePicker.stories.tsx
+++ b/src/components/Pickers/src/KeyBoardDatePicker.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
-import { KeyboardDatePicker, KeyboardDatePickerProps } from '.';
+import { KeyboardDatePicker, KeyboardDatePickerProps, DateIOType } from '.';
 import PickersUtilsProvider from '../../PickersUtilsProvider';
 import DateFnsUtils from '@date-io/date-fns';
 import pkg from '../package.json';
@@ -15,8 +15,8 @@ export default {
 
 const Template: Story<KeyboardDatePickerProps> = (args: KeyboardDatePickerProps) => {
   const [value, setValue] = React.useState('1970-01-01');
-  args.onChange = (newValue: any) => {
-    setValue(newValue);
+  args.onChange = (date: DateIOType) => {
+    setValue(date.toString());
   };
   args.value = value;
 
@@ -37,8 +37,8 @@ const [value, setValue] = React.useState('1970-01-01');
   <KeyboardDatePicker
     value={value}
     onChange={
-      (newValue: any) => {
-        setValue(newValue);
+      (date: DateIOType) => {
+        setValue(date.toString());
       }
     }
     clearable

--- a/src/components/Pickers/src/KeyboardDatePicker/KeyboardDatePicker.tsx
+++ b/src/components/Pickers/src/KeyboardDatePicker/KeyboardDatePicker.tsx
@@ -57,4 +57,6 @@ export const KeyboardDatePicker: React.FC<KeyboardDatePickerProps> = (props: Key
   return <MaterialDatePicker {...props} />;
 };
 
+
+
 export default KeyboardDatePicker;

--- a/src/components/Pickers/src/KeyboardDatePicker/KeyboardDatePicker.tsx
+++ b/src/components/Pickers/src/KeyboardDatePicker/KeyboardDatePicker.tsx
@@ -57,6 +57,6 @@ export const KeyboardDatePicker: React.FC<KeyboardDatePickerProps> = (props: Key
   return <MaterialDatePicker {...props} />;
 };
 
-
+export { DateIOType };
 
 export default KeyboardDatePicker;

--- a/src/components/PickersUtilsProvider/src/index.tsx
+++ b/src/components/PickersUtilsProvider/src/index.tsx
@@ -2,6 +2,7 @@ import { MuiPickersUtilsProvider as MaterialPickersUtilsProvider } from '@materi
 import React from 'react';
 
 export interface PickersUtilsProviderProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   utils: any;
   children: React.ReactNode;
 }
@@ -11,7 +12,11 @@ export interface PickersUtilsProviderProps {
  * @param props
  */
 export const PickersUtilsProvider: React.FC<PickersUtilsProviderProps> = (props: PickersUtilsProviderProps) => {
-  return <MaterialPickersUtilsProvider {...props}>{props.children}</MaterialPickersUtilsProvider>;
+  return (
+    <MaterialPickersUtilsProvider {...props}>
+      {props.children}
+    </MaterialPickersUtilsProvider>
+  );
 };
 
 export default PickersUtilsProvider;

--- a/src/components/Radio/src/Radio.tsx
+++ b/src/components/Radio/src/Radio.tsx
@@ -24,7 +24,7 @@ export interface RadioProps {
   /**
    * The value of the component. The DOM casts it to `string`.
    */
-  value?: any;
+  value?: unknown;
 
   /**
    * If `true`, the component is checked.
@@ -68,7 +68,7 @@ export interface RadioProps {
 }
 
 export const Radio: React.FC<RadioProps> = (props: RadioProps) => {
-  return <MaterialRadio {...props} />;
+  return <MaterialRadio {...props}/>;
 };
 
 /**

--- a/src/components/Radio/src/RadioGroup.tsx
+++ b/src/components/Radio/src/RadioGroup.tsx
@@ -26,6 +26,7 @@ export interface RadioGroupProps extends BaseChildrenProps {
   /**
    * Value of the selected radio button. The DOM API casts this to a string.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value?: any;
 
   /**

--- a/src/components/Radio/src/stories/Radio.stories.tsx
+++ b/src/components/Radio/src/stories/Radio.stories.tsx
@@ -19,7 +19,7 @@ export default {
   component: Radio,
 } as Meta;
 
-const Template: Story<RadioProps> = (args: any) => <FormControlLabel label="Radio" control={<Radio {...args} />} />;
+const Template: Story<RadioProps> = (args: RadioProps) => <FormControlLabel label="Radio" control={<Radio {...args} />} />;
 
 export const Default: Story<RadioProps> = Template.bind({});
 Default.args = {

--- a/src/components/Select/src/index.tsx
+++ b/src/components/Select/src/index.tsx
@@ -23,7 +23,7 @@ export interface SelectProps extends BaseProps {
   /**
    * The default element value. Use when the component is not controlled.
    */
-  defaultValue?: any;
+  defaultValue?: unknown;
 
   /**
    * If `true`, a value is displayed even if no items are selected.
@@ -46,6 +46,7 @@ export interface SelectProps extends BaseProps {
   /**
    * An `Input` element; does not have to be a material-ui specific `Input`.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   input?: React.ReactElement<any, any>;
 
   /**
@@ -140,7 +141,7 @@ export interface SelectProps extends BaseProps {
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    * @document
    */
-  value?: any;
+  value?: unknown;
 }
 
 /**

--- a/src/components/Stepper/src/StepContent.tsx
+++ b/src/components/Stepper/src/StepContent.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import MaterialStepContent from '@material-ui/core/StepContent';
 import BaseProps from '@gemeente-denhaag/baseprops';
+import { TransitionProps } from '@material-ui/core/transitions';
 
 export interface StepContentProps extends BaseProps {
   /**
    * The component used for the transition.
    */
-  TransitionComponent?: any;
+  TransitionComponent?: React.ComponentType<TransitionProps>;
 
   /**
    * Adjust the duration of the content expand transition.

--- a/src/components/Tab/src/Tab.tsx
+++ b/src/components/Tab/src/Tab.tsx
@@ -32,7 +32,7 @@ export interface TabProps extends BaseProps {
    * You can provide your own value.
    * Otherwise, we fallback to the child position index.
    */
-  value: any;
+  value?: number | string;
 
   /**
    * Tab labels appear in a single row.
@@ -47,7 +47,7 @@ export interface TabProps extends BaseProps {
  * @constructor Construct an instance of Tab.
  */
 export const Tab: React.FC<TabProps> = (props: TabProps) => {
-  return <MaterialTab {...props} />;
+  return <MaterialTab {...props}/>;
 };
 
 export default Tab;

--- a/src/components/Tab/src/Tabs.tsx
+++ b/src/components/Tab/src/Tabs.tsx
@@ -81,8 +81,10 @@ export interface TabsProps extends BaseProps {
   /**
    * The value of the currently selected Tab.
    * If you don't want any selected Tab, you can set this property to false.
+   * Although any value can be used, we recommend choosing either
+   * numbers or strings to identify your tabs.
    */
-  value: any | false;
+  value: number | string | false;
 
   /**
    * Determines additional display behavior of the tabs:

--- a/src/components/TextField/src/BaseTextFieldProps.ts
+++ b/src/components/TextField/src/BaseTextFieldProps.ts
@@ -64,6 +64,7 @@ export interface BaseTextFieldProps extends BaseClassesProps {
   /**
    * Pass a ref to the `input` element.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputRef?: React.Ref<any>;
 
   /**

--- a/src/components/TextField/src/index.tsx
+++ b/src/components/TextField/src/index.tsx
@@ -5,7 +5,7 @@ import { StandardTextFieldProps } from './StandardTextFieldProps';
 export type TextFieldProps = StandardTextFieldProps;
 
 export const TextField: React.FC<TextFieldProps> = (props: TextFieldProps) => {
-  return <MaterialTextField variant="standard" {...props} />;
+  return <MaterialTextField variant="standard" {...props}/>;
 };
 
 /**


### PR DESCRIPTION
**Closing issues**
closes #152 

Enabled any error in eslint, and fixed/reworked all cases where any was used.

In most cases the MUI type could be copied 1:1.
In other cases the most commonly used types were chosen (e.g. value for tab).

If there was no obviously commonly used type and MUI uses any in their docs,
 I added a disable warning comment and left it as any.

In some cases the type was too complex or deeply nested to figure out (e.g. Popover), 
in that case I chose to use the type used in the Material properties.
This should work in the current state, and once we refactor these components we can revisit them.
