### PR TITLE
Fix/format package json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,5 +7,4 @@ node_modules
 CHANGELOG.md
 dist
 package-lock.json
-package.json
 storybook-static

--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
   },
   "license": "EUPL-1.2",
   "author": "Municipality of The Hague",
-  "workspaces": [
-    "src/components/*",
-    "src/meta-packages/*",
-    "src/styles/*",
-    "src/"
-  ],
+  "workspaces": ["src/components/*", "src/meta-packages/*", "src/styles/*", "src/"],
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",

--- a/src/components/Accordion/package.json
+++ b/src/components/Accordion/package.json
@@ -1,36 +1,34 @@
 {
-    "name": "@gemeente-denhaag/accordion",
-    "version": "0.1.7",
-    "description": "An Accordion component.",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Accordion"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/icons": "*",
-        "@gemeente-denhaag/typography": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/accordion",
+  "version": "0.1.7",
+  "description": "An Accordion component.",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Accordion"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/icons": "*",
+    "@gemeente-denhaag/typography": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/AppBar/package.json
+++ b/src/components/AppBar/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@gemeente-denhaag/appbar",
-    "version": "0.1.7",
-    "description": "An AppBar component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/AppBar"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/icons": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/appbar",
+  "version": "0.1.7",
+  "description": "An AppBar component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/AppBar"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/icons": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Avatar/package.json
+++ b/src/components/Avatar/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/avatar",
-    "version": "0.1.7",
-    "description": "An Avatar component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Avatar"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/avatar",
+  "version": "0.1.7",
+  "description": "An Avatar component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Avatar"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Badge/package.json
+++ b/src/components/Badge/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@gemeente-denhaag/badge",
-    "version": "0.1.7",
-    "description": "A Badge component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Badge"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/basedatadisplayprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/icons": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/badge",
+  "version": "0.1.7",
+  "description": "A Badge component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Badge"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/basedatadisplayprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/icons": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/BaseDataDisplayProps/package.json
+++ b/src/components/BaseDataDisplayProps/package.json
@@ -1,31 +1,29 @@
 {
-    "name": "@gemeente-denhaag/basedatadisplayprops",
-    "version": "0.1.7",
-    "description": "A package containing properties used in DataDisplay",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/BaseDataDisplayProps"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/basedatadisplayprops",
+  "version": "0.1.7",
+  "description": "A package containing properties used in DataDisplay",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/BaseDataDisplayProps"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/BaseLayoutProps/package.json
+++ b/src/components/BaseLayoutProps/package.json
@@ -1,31 +1,29 @@
 {
-    "name": "@gemeente-denhaag/baselayoutprops",
-    "version": "0.1.7",
-    "description": "Properties used in layout components",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/BaseLayoutProps"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/baselayoutprops",
+  "version": "0.1.7",
+  "description": "Properties used in layout components",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/BaseLayoutProps"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/BaseProps/package.json
+++ b/src/components/BaseProps/package.json
@@ -1,28 +1,26 @@
 {
-    "name": "@gemeente-denhaag/baseprops",
-    "version": "0.1.7",
-    "description": "A package containing properties used in other components",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/BaseProps"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/baseprops",
+  "version": "0.1.7",
+  "description": "A package containing properties used in other components",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/BaseProps"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Box/package.json
+++ b/src/components/Box/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/box",
-    "version": "0.1.7",
-    "description": "A Box component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Box"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baselayoutprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/box",
+  "version": "0.1.7",
+  "description": "A Box component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Box"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baselayoutprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Button/package.json
+++ b/src/components/Button/package.json
@@ -8,9 +8,7 @@
   "module": "dist/index.js",
   "exports": "./dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b && copyfiles -u 1 \"src/**/*.css\" dist",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/components/Card/package.json
+++ b/src/components/Card/package.json
@@ -1,38 +1,36 @@
 {
-    "name": "@gemeente-denhaag/card",
-    "version": "0.1.7",
-    "description": "A Card component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Card"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/avatar": "*",
-        "@gemeente-denhaag/iconbutton": "*",
-        "@gemeente-denhaag/icons": "*",
-        "@gemeente-denhaag/typography": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/card",
+  "version": "0.1.7",
+  "description": "A Card component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Card"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/avatar": "*",
+    "@gemeente-denhaag/iconbutton": "*",
+    "@gemeente-denhaag/icons": "*",
+    "@gemeente-denhaag/typography": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Checkbox/package.json
+++ b/src/components/Checkbox/package.json
@@ -1,34 +1,32 @@
 {
-    "name": "@gemeente-denhaag/checkbox",
-    "version": "0.1.7",
-    "description": "A Checkbox component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Checkbox"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@gemeente-denhaag/formcontrollabel": "^0.1.7",
-        "@gemeente-denhaag/formgroup": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/checkbox",
+  "version": "0.1.7",
+  "description": "A Checkbox component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Checkbox"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@gemeente-denhaag/formcontrollabel": "^0.1.7",
+    "@gemeente-denhaag/formgroup": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Container/package.json
+++ b/src/components/Container/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/container",
-    "version": "0.1.7",
-    "description": "A Container component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Container"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baselayoutprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/container",
+  "version": "0.1.7",
+  "description": "A Container component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Container"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baselayoutprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Divider/package.json
+++ b/src/components/Divider/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@gemeente-denhaag/divider",
-    "version": "0.1.7",
-    "description": "A Divider component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Divider"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/basedatadisplayprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/icons": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/divider",
+  "version": "0.1.7",
+  "description": "A Divider component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Divider"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/basedatadisplayprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/icons": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Drawer/package.json
+++ b/src/components/Drawer/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/drawer",
-    "version": "0.1.7",
-    "description": "A Drawer component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Drawer"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/drawer",
+  "version": "0.1.7",
+  "description": "A Drawer component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Drawer"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/FormControl/package.json
+++ b/src/components/FormControl/package.json
@@ -1,31 +1,29 @@
 {
-    "name": "@gemeente-denhaag/formcontrol",
-    "version": "0.1.7",
-    "description": "A FormControl component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/FormControl"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/formcontrol",
+  "version": "0.1.7",
+  "description": "A FormControl component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/FormControl"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/FormControlLabel/package.json
+++ b/src/components/FormControlLabel/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/formcontrollabel",
-    "version": "0.1.7",
-    "description": "A FormControlLabel component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/FormControlLabel"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/formcontrollabel",
+  "version": "0.1.7",
+  "description": "A FormControlLabel component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/FormControlLabel"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/FormGroup/package.json
+++ b/src/components/FormGroup/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/formgroup",
-    "version": "0.1.7",
-    "description": "A FormGroup component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/FormGroup"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/formgroup",
+  "version": "0.1.7",
+  "description": "A FormGroup component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/FormGroup"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Grid/package.json
+++ b/src/components/Grid/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/grid",
-    "version": "0.1.7",
-    "description": "A Grid component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Grid"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baselayoutprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/grid",
+  "version": "0.1.7",
+  "description": "A Grid component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Grid"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baselayoutprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/GridList/package.json
+++ b/src/components/GridList/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@gemeente-denhaag/gridlist",
-    "version": "0.1.7",
-    "description": "A GridList component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/GridList"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baselayoutprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/iconbutton": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/gridlist",
+  "version": "0.1.7",
+  "description": "A GridList component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/GridList"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baselayoutprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/iconbutton": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Hidden/package.json
+++ b/src/components/Hidden/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/hidden",
-    "version": "0.1.7",
-    "description": "A Hidden component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Hidden"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/hidden",
+  "version": "0.1.7",
+  "description": "A Hidden component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Hidden"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/IconButton/package.json
+++ b/src/components/IconButton/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@gemeente-denhaag/iconbutton",
-    "version": "0.1.7",
-    "description": "An IconButton component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/IconButton"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/icons": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/iconbutton",
+  "version": "0.1.7",
+  "description": "An IconButton component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/IconButton"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/icons": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Icons/package.json
+++ b/src/components/Icons/package.json
@@ -1,31 +1,29 @@
 {
-    "name": "@gemeente-denhaag/icons",
-    "version": "0.1.0",
-    "description": "The icon set of the Municipality of The Hague",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Icons"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b && svgo --multipass -q -r -f ./src/svg -o ./dist/svg",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    }
+  "name": "@gemeente-denhaag/icons",
+  "version": "0.1.0",
+  "description": "The icon set of the Municipality of The Hague",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Icons"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b && svgo --multipass -q -r -f ./src/svg -o ./dist/svg",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  }
 }

--- a/src/components/InputLabel/package.json
+++ b/src/components/InputLabel/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/inputlabel",
-    "version": "0.1.7",
-    "description": "An InputLabel component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/InputLabel"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/inputlabel",
+  "version": "0.1.7",
+  "description": "An InputLabel component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/InputLabel"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Link/package.json
+++ b/src/components/Link/package.json
@@ -1,31 +1,29 @@
 {
-    "name": "@gemeente-denhaag/link",
-    "version": "0.0.2",
-    "description": "A Link component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/link"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    }
+  "name": "@gemeente-denhaag/link",
+  "version": "0.0.2",
+  "description": "A Link component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/link"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  }
 }

--- a/src/components/List/package.json
+++ b/src/components/List/package.json
@@ -1,38 +1,36 @@
 {
-    "name": "@gemeente-denhaag/list",
-    "version": "0.1.7",
-    "description": "A List component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/List"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/avatar": "*",
-        "@gemeente-denhaag/checkbox": "*",
-        "@gemeente-denhaag/iconbutton": "*",
-        "@gemeente-denhaag/icons": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/list",
+  "version": "0.1.7",
+  "description": "A List component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/List"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/avatar": "*",
+    "@gemeente-denhaag/checkbox": "*",
+    "@gemeente-denhaag/iconbutton": "*",
+    "@gemeente-denhaag/icons": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Menu/package.json
+++ b/src/components/Menu/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/menu",
-    "version": "0.1.7",
-    "description": "A Menu component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Menu"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/menu",
+  "version": "0.1.7",
+  "description": "A Menu component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Menu"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Pickers/package.json
+++ b/src/components/Pickers/package.json
@@ -1,37 +1,35 @@
 {
-    "name": "@gemeente-denhaag/pickers",
-    "version": "0.1.14",
-    "description": "A collection of Pickers",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Pickers"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/pickersutilsprovider": "^0.1.10",
-        "@material-ui/core": "^4.11.0",
-        "@material-ui/pickers": "^3.2.10"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@date-io/date-fns": "^1.3.13",
-        "date-fns": "^2.16.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/pickers",
+  "version": "0.1.14",
+  "description": "A collection of Pickers",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Pickers"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/pickersutilsprovider": "^0.1.10",
+    "@material-ui/core": "^4.11.0",
+    "@material-ui/pickers": "^3.2.10"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@date-io/date-fns": "^1.3.13",
+    "date-fns": "^2.16.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/PickersUtilsProvider/package.json
+++ b/src/components/PickersUtilsProvider/package.json
@@ -1,30 +1,28 @@
 {
-    "name": "@gemeente-denhaag/pickersutilsprovider",
-    "version": "0.1.10",
-    "description": "A Utilsprovider for pickers",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/PickersUtilsProvider"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@material-ui/pickers": "^3.2.10"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    }
+  "name": "@gemeente-denhaag/pickersutilsprovider",
+  "version": "0.1.10",
+  "description": "A Utilsprovider for pickers",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/PickersUtilsProvider"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@material-ui/pickers": "^3.2.10"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  }
 }

--- a/src/components/Radio/package.json
+++ b/src/components/Radio/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "@gemeente-denhaag/radio",
-    "version": "0.1.7",
-    "description": "A Radio component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Radio"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@material-ui/core": "^4.11.2"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "devDependencies": {
-        "@gemeente-denhaag/formcontrollabel": "*",
-        "@gemeente-denhaag/icons": "*"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/radio",
+  "version": "0.1.7",
+  "description": "A Radio component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Radio"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@material-ui/core": "^4.11.2"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/formcontrollabel": "*",
+    "@gemeente-denhaag/icons": "*"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Select/package.json
+++ b/src/components/Select/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/select",
-    "version": "0.1.7",
-    "description": "A Select component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Select"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/select",
+  "version": "0.1.7",
+  "description": "A Select component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Select"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Stepper/package.json
+++ b/src/components/Stepper/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/stepper",
-    "version": "0.1.7",
-    "description": "A Stepper component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Stepper"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/stepper",
+  "version": "0.1.7",
+  "description": "A Stepper component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Stepper"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/SwipeableDrawer/package.json
+++ b/src/components/SwipeableDrawer/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/swipeabledrawer",
-    "version": "0.1.7",
-    "description": "A SwipeableDrawer component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/SwipeableDrawer"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/swipeabledrawer",
+  "version": "0.1.7",
+  "description": "A SwipeableDrawer component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/SwipeableDrawer"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Switch/package.json
+++ b/src/components/Switch/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/switch",
-    "version": "0.1.7",
-    "description": "A Switch component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Switch"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/switch",
+  "version": "0.1.7",
+  "description": "A Switch component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Switch"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Tab/package.json
+++ b/src/components/Tab/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/tab",
-    "version": "0.1.7",
-    "description": "A Tab component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Tab"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/tab",
+  "version": "0.1.7",
+  "description": "A Tab component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Tab"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/TextField/package.json
+++ b/src/components/TextField/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/textfield",
-    "version": "0.1.7",
-    "description": "A TextField component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/TextField"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/textfield",
+  "version": "0.1.7",
+  "description": "A TextField component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/TextField"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Toolbar/package.json
+++ b/src/components/Toolbar/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/toolbar",
-    "version": "0.1.7",
-    "description": "Toolbar component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Toolbar"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/baseprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/toolbar",
+  "version": "0.1.7",
+  "description": "Toolbar component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Toolbar"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/components/Typography/package.json
+++ b/src/components/Typography/package.json
@@ -1,32 +1,30 @@
 {
-    "name": "@gemeente-denhaag/typography",
-    "version": "0.1.7",
-    "description": "A Typography component",
-    "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
-        "directory": "src/components/Typograhy"
-    },
-    "license": "EUPL-1.2",
-    "author": "Municipality of The Hague",
-    "exports": "./dist/index.js",
-    "main": "dist/index.js",
-    "module": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc -b",
-        "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
-    },
-    "dependencies": {
-        "@gemeente-denhaag/basedatadisplayprops": "^0.1.7",
-        "@material-ui/core": "^4.11.0"
-    },
-    "peerDependencies": {
-        "react": "^17.0.1"
-    },
-    "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+  "name": "@gemeente-denhaag/typography",
+  "version": "0.1.7",
+  "description": "A Typography component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/Typograhy"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/basedatadisplayprops": "^0.1.7",
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
 }

--- a/src/meta-packages/datadisplay/package.json
+++ b/src/meta-packages/datadisplay/package.json
@@ -12,9 +12,7 @@
   "author": "Municipality of The Hague",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/meta-packages/denhaag-component-library/package.json
+++ b/src/meta-packages/denhaag-component-library/package.json
@@ -13,9 +13,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/meta-packages/input/package.json
+++ b/src/meta-packages/input/package.json
@@ -13,9 +13,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/meta-packages/layout/package.json
+++ b/src/meta-packages/layout/package.json
@@ -13,9 +13,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/meta-packages/navigation/package.json
+++ b/src/meta-packages/navigation/package.json
@@ -13,9 +13,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/meta-packages/surfaces/package.json
+++ b/src/meta-packages/surfaces/package.json
@@ -13,9 +13,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"

--- a/src/styles/Common/package.json
+++ b/src/styles/Common/package.json
@@ -10,9 +10,7 @@
     "directory": "src/styles/Common"
   },
   "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -20,4 +18,3 @@
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   }
 }
-

--- a/src/styles/Components/package.json
+++ b/src/styles/Components/package.json
@@ -10,9 +10,7 @@
     "directory": "src/styles/Components"
   },
   "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/styles/Proprietary/package.json
+++ b/src/styles/Proprietary/package.json
@@ -10,9 +10,7 @@
     "directory": "src/styles/Proprietary"
   },
   "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -20,4 +18,3 @@
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   }
 }
-


### PR DESCRIPTION
For some reason the `package.json` files were ignore by prettier. This resulted in inconsistent tab sizes. I've removed `package.json` from `.prettierignore` and ran `prettier --write` on all package.json files.
 
**Closing issues**
no related issue
