### PR TITLE
Prevent logical spacing shorthands

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,6 @@
+# Ignore 3rd party files
+node_modules/
+
+# Ignore generated files
+dist/
+tmp/

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -56,12 +56,16 @@
     "property-disallowed-list": [
       [
         "margin",
+        "margin-block",
         "margin-bottom",
+        "margin-inline",
         "margin-left",
         "margin-right",
         "margin-top",
         "padding",
+        "padding-block",
         "padding-bottom",
+        "padding-inline",
         "padding-left",
         "padding-right",
         "padding-top"

--- a/src/components/Button/src/button.module.css
+++ b/src/components/Button/src/button.module.css
@@ -66,34 +66,54 @@
 
 /* Size specific styling */
 .denhaag-button--medium {
-  padding-inline: var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline));
-  padding-block: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));
+  padding-inline-start: var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline));
+  padding-inline-end: var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline));
+  padding-block-start: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));
+  padding-block-end: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));
   font-size: var(--denhaag-font-size-base);
 }
 
 .denhaag-button--medium.denhaag-button--secondary-action {
-  padding-inline: calc(
+  padding-inline-start: calc(
     var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline)) -
       var(--denhaag-button-border-width)
   );
-  padding-block: calc(
+  padding-inline-end: calc(
+    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline)) -
+      var(--denhaag-button-border-width)
+  );
+  padding-block-start: calc(
+    var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block)) -
+      var(--denhaag-button-border-width)
+  );
+  padding-block-end: calc(
     var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block)) -
       var(--denhaag-button-border-width)
   );
 }
 
 .denhaag-button--large {
-  padding-inline: var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline));
-  padding-block: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
+  padding-inline-start: var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline));
+  padding-inline-end: var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline));
+  padding-block-start: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
+  padding-block-end: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
   font-size: var(--denhaag-font-size-lg);
 }
 
 .denhaag-button--large.denhaag-button--secondary-action {
-  padding-inline: calc(
+  padding-inline-start: calc(
     var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline)) -
       var(--denhaag-button-border-width)
   );
-  padding-block: calc(
+  padding-inline-end: calc(
+    var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline)) -
+      var(--denhaag-button-border-width)
+  );
+  padding-block-start: calc(
+    var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block)) -
+      var(--denhaag-button-border-width)
+  );
+  padding-block-end: calc(
     var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block)) -
       var(--denhaag-button-border-width)
   );


### PR DESCRIPTION
Since sometimes the following properties are included in the codebase, even though they are not widely supported by browsers, I suggest to include linting rules to warn against their usage:

https://github.com/Gemeente-DenHaag/denhaag-component-library/pull/134#discussion_r648057710


- [`margin-block`](https://caniuse.com/?search=margin-block)
- [`margin-inline`](https://caniuse.com/?search=margin-inline)
- [`padding-block`](https://caniuse.com/?search=padding-block)
- [`padding-inline`](https://caniuse.com/?search=padding-inline)