### PR TITLE
fix/copyfiles-divider

### DIFF
--- a/src/components/Divider/package.json
+++ b/src/components/Divider/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && copyfiles -u 1 \"src/**/*.css\" dist",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes a current issue with Divider where .css is not copied to /dist.
This causes issues with our current approach of building components. 
